### PR TITLE
Major overhaul of the powershell script 

### DIFF
--- a/DiscoverScheduledTasks.ps1
+++ b/DiscoverScheduledTasks.ps1
@@ -76,4 +76,8 @@ switch ($taskAction) {
         $taskState = (Get-ScheduledTaskByFullName $taskPath $taskName).State
         Write-Output $taskState
     }
+
+    Default {
+        throw "Error trying getting  task action: $taskAction"
+    }
 }

--- a/DiscoverScheduledTasks.ps1
+++ b/DiscoverScheduledTasks.ps1
@@ -1,11 +1,13 @@
 # Script: DiscoverSchelduledTasks
 # Author: Romain Si
 # Revision: Isaac de Moraes
+# Revision: Patrik Svestka
+#
 # This script is intended for use with Zabbix > 3.x
 #
 #
 # Add to Zabbix Agent
-# UserParameter=TaskSchedulerMonitoring[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\DiscoverScheduledTasks.ps1" "$1" "$2"
+# UserParameter=TaskSchedulerMonitoring[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\DiscoverScheduledTasks.ps1" "$1" "$2" "$3"
 #
 ## Modifier la variable $path pour indiquer les sous dossiers de Tâches Planifiées à traiter sous la forme "\nomDossier\","\nomdossier2\sousdossier\" voir (Get-ScheduledTask -TaskPath )
 ## Change the $path variable to indicate the Scheduled Tasks subfolder to be processed as "\nameFolder\","\nameFolder2\subfolder\" see (Get-ScheduledTask -TaskPath )

--- a/DiscoverScheduledTasks.ps1
+++ b/DiscoverScheduledTasks.ps1
@@ -5,12 +5,18 @@
 #
 # This script is intended for use with Zabbix > 3.x
 #
-#
 # Add to Zabbix Agent
 # UserParameter=TaskSchedulerMonitoring[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\DiscoverScheduledTasks.ps1" "$1" "$2" "$3"
 #
 # Note: should there be a need to use wild char star (*) in the task path - it is considered to be an unsafe character in Zabbix- it needs to be enabled
 #       in zabbix_agent2.conf using UnsafeUserParameters=1
+#
+# Examples when running directly from PowerShell:
+#
+# 1) List all tasks at the path /Accounting/ including the subfolders and list the /backup/ only
+#   `.\DiscoverSchelduledTasks.ps1 '/Accounting/*,/Backup/' 'DiscoverTasks'`
+# 2) Show the last task result for the AccoungDailyBackup task
+#    `'.\DiscoverSchelduledTasks.ps1 '/Accounting/' 'TaskLastResult' 'AccountingDailyBackup'`
 #
 ## Modifier la variable $path pour indiquer les sous dossiers de Tâches Planifiées à traiter sous la forme "\nomDossier\","\nomdossier2\sousdossier\" voir (Get-ScheduledTask -TaskPath )
 ## Change the $path variable to indicate the Scheduled Tasks subfolder to be processed as "\nameFolder\","\nameFolder2\subfolder\" see (Get-ScheduledTask -TaskPath )
@@ -33,12 +39,11 @@ function Get-ScheduledTaskByFullName($path, $name) {
 }
 
 # Zabbix template is using the forward slash (/) instead of the Task schedule XML's backslash (\) - changing to the proper XML's style
-# Note: The backslash and star (*) are considered unsafe character in Zabbix
+# Note: The backslash are considered unsafe character in Zabbix, same as star (*) above
 $taskPath = ([string]$args[0]).replace('/','\')
 $taskAction = [string]$args[1]
 # getting only portion task name from the task path and name
 $taskName = ([string]$args[2]).Substring(([string]$args[2]).LastIndexOf('/') + 1)
-
 
 switch ($taskAction) {
     'DiscoverTasks' {

--- a/DiscoverScheduledTasks.ps1
+++ b/DiscoverScheduledTasks.ps1
@@ -4,6 +4,7 @@
 # Revision: Patrik Svestka
 #
 # This script is intended for use with Zabbix > 3.x
+# Note: This script uses front slash in the path instead of Task Schedule's backslash path (XML) as the backslash are considered unsafe character in Zabbix
 #
 # Add to Zabbix Agent
 # UserParameter=TaskSchedulerMonitoring[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\DiscoverScheduledTasks.ps1" "$1" "$2" "$3"
@@ -17,9 +18,6 @@
 #   `.\DiscoverSchelduledTasks.ps1 '/Accounting/*,/Backup/' 'DiscoverTasks'`
 # 2) Show the last task result for the AccoungDailyBackup task
 #    `'.\DiscoverSchelduledTasks.ps1 '/Accounting/' 'TaskLastResult' 'AccountingDailyBackup'`
-#
-## Modifier la variable $path pour indiquer les sous dossiers de Tâches Planifiées à traiter sous la forme "\nomDossier\","\nomdossier2\sousdossier\" voir (Get-ScheduledTask -TaskPath )
-## Change the $path variable to indicate the Scheduled Tasks subfolder to be processed as "\nameFolder\","\nameFolder2\subfolder\" see (Get-ScheduledTask -TaskPath )
 
 $ErrorActionPreference = "Stop"
 
@@ -39,7 +37,6 @@ function Get-ScheduledTaskByFullName($path, $name) {
 }
 
 # Zabbix template is using the forward slash (/) instead of the Task schedule XML's backslash (\) - changing to the proper XML's style
-# Note: The backslash are considered unsafe character in Zabbix, same as star (*) above
 $taskPath = ([string]$args[0]).replace('/','\')
 $taskAction = [string]$args[1]
 # getting only portion task name from the task path and name

--- a/DiscoverScheduledTasks.ps1
+++ b/DiscoverScheduledTasks.ps1
@@ -9,6 +9,9 @@
 # Add to Zabbix Agent
 # UserParameter=TaskSchedulerMonitoring[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\DiscoverScheduledTasks.ps1" "$1" "$2" "$3"
 #
+# Note: should there be a need to use wild char star (*) in the task path - it is considered to be an unsafe character in Zabbix- it needs to be enabled
+#       in zabbix_agent2.conf using UnsafeUserParameters=1
+#
 ## Modifier la variable $path pour indiquer les sous dossiers de Tâches Planifiées à traiter sous la forme "\nomDossier\","\nomdossier2\sousdossier\" voir (Get-ScheduledTask -TaskPath )
 ## Change the $path variable to indicate the Scheduled Tasks subfolder to be processed as "\nameFolder\","\nameFolder2\subfolder\" see (Get-ScheduledTask -TaskPath )
 

--- a/DiscoverScheduledTasks.ps1
+++ b/DiscoverScheduledTasks.ps1
@@ -14,7 +14,7 @@
 
 $ErrorActionPreference = "Stop"
 
-Function Convert-ToUnixDate($PSdate) {
+function Convert-ToUnixDate($PSdate) {
 	$epoch = [timezone]::CurrentTimeZone.ToLocalTime([datetime]'1/1/1970')
 	if ($PSdate -eq $Null) {
 		$PSdate = $epoch
@@ -66,7 +66,6 @@ switch ($Item) {
 		$taskResult = Get-ScheduledTaskInfoByFullName $Id
 
 		$taskResult1 = $taskResult.LastRunTime
-		$date = get-date -date "01/01/1970"
 		$taskResult2 = Convert-ToUnixDate($taskResult1)
 		Write-Output ($taskResult2)
 	}
@@ -75,7 +74,6 @@ switch ($Item) {
 		$taskResult = Get-ScheduledTaskInfoByFullName $Id
 
 		$taskResult1 = $taskResult.NextRunTime
-		$date = get-date -date "01/01/1970"
 		$taskResult2 = Convert-ToUnixDate($taskResult1)
 		Write-Output ($taskResult2)
 	}

--- a/DiscoverScheduledTasks.ps1
+++ b/DiscoverScheduledTasks.ps1
@@ -17,12 +17,11 @@
 
 $ErrorActionPreference = "Stop"
 
-function Convert-ToUnixDate($PSdate) {
-	$epoch = [timezone]::CurrentTimeZone.ToLocalTime([datetime]'1/1/1970')
-	if ($PSdate -eq $Null) {
-		$PSdate = $epoch
-	}
-	(New-TimeSpan -Start $epoch -End $PSdate).TotalSeconds
+function Convert-ToUnixDate($taskTime) {
+    $epoch = [timezone]::CurrentTimeZone.ToLocalTime([datetime]'1/1/1970')
+    if ($taskTime -eq $Null) { $taskTime = $epoch }
+    
+    return (New-TimeSpan -Start $epoch -End $taskTime).TotalSeconds
 }
 
 function Get-ScheduledTaskByFullName($fullname) {

--- a/README.md
+++ b/README.md
@@ -2,17 +2,23 @@
 
 ## Step 1:
 #### Copy the file DiscoverScheduledTasks.ps1 for folder of Zabbix Agent
-#### Normally is in "C:\Zabbix\"
+#### Normally is in `"C:\Program Files\Zabbix Agent 2"\`
 
 ## Step 2:
 #### Add host level macro {$TASKPATHS} (open host properties and look for the "Macros" tab) and specify your tasks location(s) in Task Scheduler Library, root is "/", custom folder may be "/CustomFolder/", several locations will be comma-separated: "/,/CustomFolder/"
 
 ## Step 3:
 #### In the configuration file of Zabbix Agent add the following parameters:
-    
-    Timeout=30
 
-    UserParameter=TaskSchedulerMonitoring[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix\DiscoverScheduledTasks.ps1" "$1" "$2" "$3"
+    `Timeout=30`
+    
+> for Powershell < 7.x
+    
+    `UserParameter=TaskSchedulerMonitoring[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix\DiscoverScheduledTasks.ps1" "$1" "$2" "$3"`
+    
+> for Powershell > 7.x
+    
+    `UserParameter=TaskSchedulerMonitoring[*],"C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -File "c:\Services\Zabbix\scripts\DiscoverScheduledTasks.ps1" "$1"  "$2" "$3"`
 
 ## Step 4:
 #### Verify if your Windows Hosts is enable for execute scripts, if no, run in powershell:

--- a/Template_Tasks_Z6.0.xml
+++ b/Template_Tasks_Z6.0.xml
@@ -13,7 +13,7 @@
             <uuid>57954842d3fb43c5923be6da6458432f</uuid>
             <template>Template Windows Task Scheduled</template>
             <name>Template Windows Task Scheduled</name>
-            <description>Discover and monitor all Task from &quot;Task Scheduler Library&quot; with subfolders indicate in powershell script.</description>
+            <description>Discover and monitor all Task from &quot;Task Scheduler Library&quot; with sub-folders indicate in powershell script.</description>
             <groups>
                 <group>
                     <name>Templates</name>
@@ -36,7 +36,7 @@
                         </conditions>
                     </filter>
                     <lifetime>0</lifetime>
-                    <description>Discover all Task at &quot;Task Scheduler Libraray&quot; with Subfolders indicate in powershell script.</description>
+                    <description>Discover all Task at &quot;Task Scheduler Library&quot; with Sub-folders indicate in powershell script.</description>
                     <item_prototypes>
                         <item_prototype>
                             <uuid>68b168b5266c4f66864a99065c2549c3</uuid>
@@ -44,7 +44,7 @@
                             <key>TaskSchedulerMonitoring[{$TASKPATHS},TaskLastResult,{#APPTASKS}]</key>
                             <delay>1h</delay>
                             <description>Last Result of Task, numeric value
- in most cases 0 = succesfull</description>
+ in most cases 0 = successful</description>
                             <valuemap>
                                 <name>Task Scheduled</name>
                             </valuemap>

--- a/Template_Tasks_Z6.0.xml
+++ b/Template_Tasks_Z6.0.xml
@@ -13,7 +13,7 @@
             <uuid>57954842d3fb43c5923be6da6458432f</uuid>
             <template>Template Windows Task Scheduled</template>
             <name>Template Windows Task Scheduled</name>
-            <description>Discover and monitor all Task from &quot;Task Scheduler Library&quot; with sub-folders indicate in powershell script.</description>
+            <description>Discover and monitor all Task from &quot;Task Scheduler Library&quot; with subfolders indicate in powershell script.</description>
             <groups>
                 <group>
                     <name>Templates</name>
@@ -36,7 +36,7 @@
                         </conditions>
                     </filter>
                     <lifetime>0</lifetime>
-                    <description>Discover all Task at &quot;Task Scheduler Library&quot; with Sub-folders indicate in powershell script.</description>
+                    <description>Discover all Task at &quot;Task Scheduler Library&quot; with Subfolders indicate in powershell script.</description>
                     <item_prototypes>
                         <item_prototype>
                             <uuid>68b168b5266c4f66864a99065c2549c3</uuid>

--- a/Zabbix-ScheduledTask.txt
+++ b/Zabbix-ScheduledTask.txt
@@ -1,2 +1,5 @@
 Timeout=30
+# For PowerShell < 7.x
 UserParameter=TaskSchedulerMonitoring[*],powershell -NoProfile -ExecutionPolicy Bypass -File "c:\Services\Zabbix\scripts\DiscoverScheduledTasks.ps1" "$1" "$2" "$3"
+# For PowerShell > 7.x
+UserParameter=TaskSchedulerMonitoring[*],"C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -File "c:\Services\Zabbix\scripts\DiscoverScheduledTasks.ps1" "$1" "$2" "$3"


### PR DESCRIPTION
These changes now support:
 - accented characters in the task name
 - wild characters in the task name and path (must be allowed in zabbix agent configuration)
 - refactoring using the  substring() only in places needed and once, if possible
 - improving readability of the script, removing superfluous code
 - adding information about PowerShell 7.x (adding it into .txt and .md files)
 - improving, adding comments